### PR TITLE
Fix adding callback on fs.writeFile() function.

### DIFF
--- a/deployment/manifest-generator/app.js
+++ b/deployment/manifest-generator/app.js
@@ -81,7 +81,9 @@ for (let i = 0; i < _filelist.length; i++) {
 };
 
 fs.writeFile(args.output, JSON.stringify(_manifest, null, 4), function(err, result) {
-     if(err) console.log('error', err);
+    if (err) {
+        console.error(err);
+    }
 });
 
 console.log(`Manifest file ${args.output} generated.`);

--- a/deployment/manifest-generator/app.js
+++ b/deployment/manifest-generator/app.js
@@ -80,5 +80,8 @@ for (let i = 0; i < _filelist.length; i++) {
     _manifest.files.push(_filelist[i].replace(`${args.target}/`, ''));
 };
 
-fs.writeFile(args.output, JSON.stringify(_manifest, null, 4));
+fs.writeFile(args.output, JSON.stringify(_manifest, null, 4), function(err, result) {
+     if(err) console.log('error', err);
+});
+
 console.log(`Manifest file ${args.output} generated.`);


### PR DESCRIPTION
*Issue #callback neccesary on fs.writeFile()*

*On MacOS if callback function on fs.wtriteFile is not present, it not generate the manifiest file.
According https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
